### PR TITLE
Adjust to use JSDoc types from tbtc.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "build/index.js",
+  "type": "module",
   "scripts": {
-    "patch-tbtc": "babel --plugins @babel/plugin-transform-modules-commonjs node_modules/@keep-network/tbtc.js/ -d node_modules/@keep-network/tbtc.js/ && sed -i -e 's/  \"type\": \"module\",//' node_modules/@keep-network/tbtc.js/package.json",
-    "build": "tsc && npm run patch-tbtc",
+    "build": "tsc",
     "lint": "eslint src --ext ts --no-ignore --fix && prettier --write \"src/**/*.ts\"",
-    "start": "node build/index.js",
+    "start": "node --experimental-modules build/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -4,24 +4,3 @@ interface server {
   protocol: string;
 }
 
-declare module "@keep-network/tbtc.js" {
-  import BN from "bn.js";
-
-  export function withConfig(config: {
-    web3: any;
-    bitcoinNetwork: string;
-    electrum: {
-      testnet: server;
-      testnetWS: server;
-    };
-  }): Promise<{
-    Deposit: {
-      withAddress(
-        address: string
-      ): Promise<{
-        getCollateralizationPercentage(): Promise<BN>;
-        getUndercollateralizedThresholdPercent(): Promise<BN>;
-      }>;
-    };
-  }>;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "strict": true,  
     "esModuleInterop": true,
     "allowJs":true,
+    "moduleResolution": "node",
     "skipLibCheck": false, 
     "outDir": "build",
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "declaration": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "maxNodeModuleJsDepth": 2
   },
   "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
To properly build TypeScript that will run, moduleResolution: "node" and
"target": "es6" are added. To properly resolve JSDoc types,
"maxNodeModuleJsDepth": 2 is added. Finally, to properly run the
top-level ES6 module, the --experimental-modules flag is added.

Took a quick pass here, not sure if this will solve all your issues but have a
look. You'll probably need to point this to one of the draft PR branches from
tbtc.js, maybe something like `github.com/keep-network/tbtc.js#type-bins`
as the package.json reference, as the types on the current RC package are
still a bit of a mess.